### PR TITLE
Fix media description capture and coinflip timing

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -197,7 +197,8 @@ def has_user_achievement(user_id: int, code: str) -> bool:
 
 
 def get_achievement_users(code: str) -> int:
-    return Database().session.query(func.count()).filter(
+    session = Database().session
+    return session.query(func.count(UserAchievement.user_id)).filter(
         UserAchievement.achievement_code == code
     ).scalar()
 

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -28,6 +28,7 @@ from bot.database.methods import (
     get_category_parent,
     get_item_info,
     get_user_count,
+    get_user_language,
     select_admins,
     select_all_operations,
     select_all_orders,
@@ -1447,7 +1448,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_media',
                                 content_types=['photo', 'video'])
     dp.register_message_handler(assign_photo_receive_desc,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc')
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc',
+                                content_types=['text'])
     dp.register_message_handler(check_item_name_for_update,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'check_item_name')
     dp.register_message_handler(update_item_name,

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -684,6 +684,7 @@ async def coinflip_receive_bet(message: Message):
                 await bot.send_animation(user_id, f)
         except Exception:
             pass
+        await asyncio.sleep(4)
         win = result == side
         stats = TgConfig.COINFLIP_STATS.setdefault(user_id, {'games':0,'wins':0,'losses':0,'profit':0})
         stats['games'] += 1
@@ -842,6 +843,7 @@ async def coinflip_join_handler(call: CallbackQuery):
         await bot.send_animation(user_id, InputFile(gif_path))
     except Exception:
         pass
+    await asyncio.sleep(4)
     if result == creator_side:
         winner_id, loser_id = creator_id, user_id
     else:


### PR DESCRIPTION
## Summary
- ensure media description input handler accepts text messages
- delay coinflip result announcement by 4 seconds after animations
- correct achievement user count query
- import language helper in photo-description handler to avoid NameError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5b9896c8332a9e1e99e88f5d51c