### PR TITLE
Fix media description capture, coinflip timing, and promo code reuse

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -197,7 +197,8 @@ def has_user_achievement(user_id: int, code: str) -> bool:
 
 
 def get_achievement_users(code: str) -> int:
-    return Database().session.query(func.count()).filter(
+    session = Database().session
+    return session.query(func.count(UserAchievement.user_id)).filter(
         UserAchievement.achievement_code == code
     ).scalar()
 

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -28,6 +28,7 @@ from bot.database.methods import (
     get_category_parent,
     get_item_info,
     get_user_count,
+    get_user_language,
     select_admins,
     select_all_operations,
     select_all_orders,
@@ -1447,7 +1448,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_media',
                                 content_types=['photo', 'video'])
     dp.register_message_handler(assign_photo_receive_desc,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc')
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc',
+                                content_types=['text'])
     dp.register_message_handler(check_item_name_for_update,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'check_item_name')
     dp.register_message_handler(update_item_name,

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -684,6 +684,7 @@ async def coinflip_receive_bet(message: Message):
                 await bot.send_animation(user_id, f)
         except Exception:
             pass
+        await asyncio.sleep(4)
         win = result == side
         stats = TgConfig.COINFLIP_STATS.setdefault(user_id, {'games':0,'wins':0,'losses':0,'profit':0})
         stats['games'] += 1
@@ -842,6 +843,7 @@ async def coinflip_join_handler(call: CallbackQuery):
         await bot.send_animation(user_id, InputFile(gif_path))
     except Exception:
         pass
+    await asyncio.sleep(4)
     if result == creator_side:
         winner_id, loser_id = creator_id, user_id
     else:
@@ -1002,6 +1004,7 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
 
     lang = get_user_language(user_id) or 'en'
     TgConfig.STATE[user_id] = None
+    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
     TgConfig.STATE[f'{user_id}_pending_item'] = item_name
     TgConfig.STATE[f'{user_id}_price'] = price
     text = t(lang, 'confirm_purchase', item=display_name(item_name), price=price)
@@ -1015,6 +1018,9 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
 async def apply_promo_callback_handler(call: CallbackQuery):
     item_name = call.data[len('applypromo_'):]
     bot, user_id = await get_bot_user_ids(call)
+    if TgConfig.STATE.get(f'{user_id}_promo_applied'):
+        await call.answer('Promo code already applied', show_alert=True)
+        return
     lang = get_user_language(user_id) or 'en'
     TgConfig.STATE[user_id] = 'wait_promo'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
@@ -1040,6 +1046,7 @@ async def process_promo_code(message: Message):
         discount = promo['discount']
         new_price = round(price * (100 - discount) / 100, 2)
         TgConfig.STATE[f'{user_id}_price'] = new_price
+        TgConfig.STATE[f'{user_id}_promo_applied'] = True
         text = t(lang, 'promo_applied', price=new_price)
     else:
         text = t(lang, 'promo_invalid')
@@ -1047,7 +1054,7 @@ async def process_promo_code(message: Message):
         chat_id=message.chat.id,
         message_id=message_id,
         text=text,
-        reply_markup=confirm_purchase_menu(item_name, lang)
+        reply_markup=confirm_purchase_menu(item_name, lang, show_promo=False)
     )
     TgConfig.STATE[user_id] = None
 
@@ -1219,6 +1226,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                         f" bought 1 item of {value_data['item_name']} for {item_price}€")
             TgConfig.STATE.pop(f'{user_id}_pending_item', None)
             TgConfig.STATE.pop(f'{user_id}_price', None)
+            TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
             recipient = gift_to or user_id
             recipient_lang = get_user_language(recipient) or lang
             asyncio.create_task(schedule_feedback(bot, recipient, recipient_lang))
@@ -1231,6 +1239,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                                             reply_markup=back(f'item_{item_name}'))
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id}_gift_to', None)
         TgConfig.STATE.pop(f'{user_id}_gift_name', None)
         return
@@ -1246,6 +1255,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
         )
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         return
     if not value_data['is_infinity']:
         buy_item(value_data['id'], value_data['is_infinity'])
@@ -1952,6 +1962,7 @@ async def checking_payment(call: CallbackQuery):
                         logger.info(f"User {user_id} unlocked achievement first_purchase")
                     TgConfig.STATE.pop(f'{user_id}_pending_item', None)
                     TgConfig.STATE.pop(f'{user_id}_price', None)
+                    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
                     TgConfig.STATE.pop(f'{user_id}_deduct', None)
                     await bot.send_message(user_id, t(lang, 'top_up_completed'))
                     if not has_user_achievement(user_id, 'first_topup'):
@@ -1970,6 +1981,7 @@ async def checking_payment(call: CallbackQuery):
                     )
                     TgConfig.STATE.pop(f'{user_id}_pending_item', None)
                     TgConfig.STATE.pop(f'{user_id}_price', None)
+                    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
 
                     await bot.send_message(user_id, t(lang, 'top_up_completed'))
 
@@ -2037,6 +2049,7 @@ async def cancel_payment(call: CallbackQuery):
                     await notify_restock(bot, purchase_data['item'])
         TgConfig.STATE.pop(f'{user_id_db}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id_db}_price', None)
+        TgConfig.STATE.pop(f'{user_id_db}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id_db}_deduct', None)
         try:
             await bot.delete_message(user_id_db, message_id)
@@ -2073,6 +2086,7 @@ async def check_sub_to_channel(call: CallbackQuery):
                     await notify_restock(bot, purchase_data['item'])
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id}_deduct', None)
         reserve_msg_id = TgConfig.STATE.pop(f'{user_id}_reserve_msg', None)
         if reserve_msg_id:

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -258,12 +258,15 @@ def console(role: int) -> InlineKeyboardMarkup:
     inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
-def confirm_purchase_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
+def confirm_purchase_menu(item_name: str, lang: str, show_promo: bool = True) -> InlineKeyboardMarkup:
     inline_keyboard = [
-        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')],
-        [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')],
-        [InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')]
+        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')]
     ]
+    if show_promo:
+        inline_keyboard.append(
+            [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')]
+        )
+    inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 


### PR DESCRIPTION
## Summary
- ensure media description input handler accepts text messages
- delay coinflip result announcement by 4 seconds after animations
- correct achievement user count query
- import language helper in photo-description handler to avoid NameError
- enforce single-use promo codes by tracking usage and hiding the apply option

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5b9896c8332a9e1e99e88f5d51c