### PR TITLE
Fix media description capture, coinflip timing, promo code reuse, and balance invoicing

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -197,7 +197,8 @@ def has_user_achievement(user_id: int, code: str) -> bool:
 
 
 def get_achievement_users(code: str) -> int:
-    return Database().session.query(func.count()).filter(
+    session = Database().session
+    return session.query(func.count(UserAchievement.user_id)).filter(
         UserAchievement.achievement_code == code
     ).scalar()
 

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -28,6 +28,7 @@ from bot.database.methods import (
     get_category_parent,
     get_item_info,
     get_user_count,
+    get_user_language,
     select_admins,
     select_all_operations,
     select_all_orders,
@@ -1447,7 +1448,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_media',
                                 content_types=['photo', 'video'])
     dp.register_message_handler(assign_photo_receive_desc,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc')
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc',
+                                content_types=['text'])
     dp.register_message_handler(check_item_name_for_update,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'check_item_name')
     dp.register_message_handler(update_item_name,

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -258,12 +258,15 @@ def console(role: int) -> InlineKeyboardMarkup:
     inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
-def confirm_purchase_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
+def confirm_purchase_menu(item_name: str, lang: str, show_promo: bool = True) -> InlineKeyboardMarkup:
     inline_keyboard = [
-        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')],
-        [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')],
-        [InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')]
+        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')]
     ]
+    if show_promo:
+        inline_keyboard.append(
+            [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')]
+        )
+    inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
@@ -614,33 +617,6 @@ def crypto_choice() -> InlineKeyboardMarkup:
          InlineKeyboardButton('ETH', callback_data='crypto_ETH')],
         [InlineKeyboardButton('LTC', callback_data='crypto_LTC')],
         [InlineKeyboardButton('🔙 Go back', callback_data='replenish_balance')]
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
-def crypto_choice_purchase(item_name: str, lang: str) -> InlineKeyboardMarkup:
-    """Return crypto choice markup for product purchase."""
-    inline_keyboard = [
-        [InlineKeyboardButton('SOL', callback_data='buycrypto_SOL'),
-         InlineKeyboardButton('BTC', callback_data='buycrypto_BTC')],
-        [InlineKeyboardButton('TRX', callback_data='buycrypto_TRX'),
-         InlineKeyboardButton('TON', callback_data='buycrypto_TON')],
-        [InlineKeyboardButton('USDT (TRC20)', callback_data='buycrypto_USDTTRC20'),
-         InlineKeyboardButton('ETH', callback_data='buycrypto_ETH')],
-        [InlineKeyboardButton('LTC', callback_data='buycrypto_LTC')],
-        [InlineKeyboardButton(t(lang, 'back'), callback_data=f'item_{item_name}')],
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
-
-
-
-
-def use_balance_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
-    """Ask whether to use current balance for purchase."""
-    inline_keyboard = [
-        [
-            InlineKeyboardButton(t(lang, 'yes'), callback_data='use_balance_yes'),
-            InlineKeyboardButton(t(lang, 'no'), callback_data='use_balance_no'),
-        ],
-        [InlineKeyboardButton(t(lang, 'back'), callback_data=f'item_{item_name}')],
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 


### PR DESCRIPTION
## Summary
- ensure media description input handler accepts text messages
- delay coinflip result announcement by 4 seconds after animations
- correct achievement user count query
- import language helper in photo-description handler to avoid NameError
- enforce single-use promo codes by tracking usage and hiding the apply option
- automatically deduct user balance and invoice only the remaining amount when purchasing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5b9896c8332a9e1e99e88f5d51c