### PR TITLE
Fix media description capture, coinflip timing, promo code reuse, balance invoicing, and loyalty level info

### DIFF
--- a/bot/database/methods/read.py
+++ b/bot/database/methods/read.py
@@ -197,7 +197,8 @@ def has_user_achievement(user_id: int, code: str) -> bool:
 
 
 def get_achievement_users(code: str) -> int:
-    return Database().session.query(func.count()).filter(
+    session = Database().session
+    return session.query(func.count(UserAchievement.user_id)).filter(
         UserAchievement.achievement_code == code
     ).scalar()
 

--- a/bot/handlers/admin/shop_management_states.py
+++ b/bot/handlers/admin/shop_management_states.py
@@ -28,6 +28,7 @@ from bot.database.methods import (
     get_category_parent,
     get_item_info,
     get_user_count,
+    get_user_language,
     select_admins,
     select_all_operations,
     select_all_orders,
@@ -1447,7 +1448,8 @@ def register_shop_management(dp: Dispatcher) -> None:
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_media',
                                 content_types=['photo', 'video'])
     dp.register_message_handler(assign_photo_receive_desc,
-                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc')
+                                lambda c: TgConfig.STATE.get(c.from_user.id) == 'assign_photo_wait_desc',
+                                content_types=['text'])
     dp.register_message_handler(check_item_name_for_update,
                                 lambda c: TgConfig.STATE.get(c.from_user.id) == 'check_item_name')
     dp.register_message_handler(update_item_name,

--- a/bot/handlers/user/main.py
+++ b/bot/handlers/user/main.py
@@ -53,7 +53,7 @@ from bot.utils.files import cleanup_item_file
 def build_menu_text(user_obj, balance: float, purchases: int, streak: int, lang: str) -> str:
     """Return main menu text with loyalty status and streak."""
     mention = f"<a href='tg://user?id={user_obj.id}'>{html.escape(user_obj.full_name)}</a>"
-    level_name, _ = get_level_info(purchases, lang)
+    level_name, _, _ = get_level_info(purchases, lang)
     status = f"👤 Status: {level_name}"
     streak_line = t(lang, 'streak', days=streak)
     return (
@@ -684,6 +684,7 @@ async def coinflip_receive_bet(message: Message):
                 await bot.send_animation(user_id, f)
         except Exception:
             pass
+        await asyncio.sleep(4)
         win = result == side
         stats = TgConfig.COINFLIP_STATS.setdefault(user_id, {'games':0,'wins':0,'losses':0,'profit':0})
         stats['games'] += 1
@@ -842,6 +843,7 @@ async def coinflip_join_handler(call: CallbackQuery):
         await bot.send_animation(user_id, InputFile(gif_path))
     except Exception:
         pass
+    await asyncio.sleep(4)
     if result == creator_side:
         winner_id, loser_id = creator_id, user_id
     else:
@@ -928,7 +930,7 @@ async def item_info_callback_handler(call: CallbackQuery):
     category = item_info_list['category_name']
     lang = get_user_language(user_id) or 'en'
     purchases = select_user_items(user_id)
-    _, discount = get_level_info(purchases, lang)
+    _, discount, _ = get_level_info(purchases, lang)
     price = round(item_info_list["price"] * (100 - discount) / 100, 2)
     markup = item_info(item_name, category, lang)
     await bot.edit_message_text(
@@ -994,7 +996,7 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
         return
     lang = get_user_language(user_id) or 'en'
     purchases = select_user_items(user_id)
-    _, discount = get_level_info(purchases, lang)
+    _, discount, _ = get_level_info(purchases, lang)
     user = check_user(user_id)
     price = round(info['price'] * (100 - discount) / 100, 2)
     if user and user.streak_discount:
@@ -1002,6 +1004,7 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
 
     lang = get_user_language(user_id) or 'en'
     TgConfig.STATE[user_id] = None
+    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
     TgConfig.STATE[f'{user_id}_pending_item'] = item_name
     TgConfig.STATE[f'{user_id}_price'] = price
     text = t(lang, 'confirm_purchase', item=display_name(item_name), price=price)
@@ -1015,6 +1018,9 @@ async def confirm_buy_callback_handler(call: CallbackQuery):
 async def apply_promo_callback_handler(call: CallbackQuery):
     item_name = call.data[len('applypromo_'):]
     bot, user_id = await get_bot_user_ids(call)
+    if TgConfig.STATE.get(f'{user_id}_promo_applied'):
+        await call.answer('Promo code already applied', show_alert=True)
+        return
     lang = get_user_language(user_id) or 'en'
     TgConfig.STATE[user_id] = 'wait_promo'
     TgConfig.STATE[f'{user_id}_message_id'] = call.message.message_id
@@ -1040,6 +1046,7 @@ async def process_promo_code(message: Message):
         discount = promo['discount']
         new_price = round(price * (100 - discount) / 100, 2)
         TgConfig.STATE[f'{user_id}_price'] = new_price
+        TgConfig.STATE[f'{user_id}_promo_applied'] = True
         text = t(lang, 'promo_applied', price=new_price)
     else:
         text = t(lang, 'promo_invalid')
@@ -1047,7 +1054,7 @@ async def process_promo_code(message: Message):
         chat_id=message.chat.id,
         message_id=message_id,
         text=text,
-        reply_markup=confirm_purchase_menu(item_name, lang)
+        reply_markup=confirm_purchase_menu(item_name, lang, show_promo=False)
     )
     TgConfig.STATE[user_id] = None
 
@@ -1079,9 +1086,6 @@ async def buy_item_callback_handler(call: CallbackQuery):
             else:
                 add_bought_item(value_data['item_name'], value_data['value'], item_price, user_id, formatted_time)
             purchases = purchases_before + 1
-            level_before, _ = get_level_info(purchases_before, lang)
-            level_after, discount = get_level_info(purchases, lang)
-
             level_before, _, _ = get_level_info(purchases_before, lang)
             level_after, discount, _ = get_level_info(purchases, lang)
             if level_after != level_before:
@@ -1219,6 +1223,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                         f" bought 1 item of {value_data['item_name']} for {item_price}€")
             TgConfig.STATE.pop(f'{user_id}_pending_item', None)
             TgConfig.STATE.pop(f'{user_id}_price', None)
+            TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
             recipient = gift_to or user_id
             recipient_lang = get_user_language(recipient) or lang
             asyncio.create_task(schedule_feedback(bot, recipient, recipient_lang))
@@ -1231,6 +1236,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
                                             reply_markup=back(f'item_{item_name}'))
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id}_gift_to', None)
         TgConfig.STATE.pop(f'{user_id}_gift_name', None)
         return
@@ -1246,6 +1252,7 @@ async def buy_item_callback_handler(call: CallbackQuery):
         )
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         return
     if not value_data['is_infinity']:
         buy_item(value_data['id'], value_data['is_infinity'])
@@ -1264,49 +1271,6 @@ async def buy_item_callback_handler(call: CallbackQuery):
     if gift_to:
         TgConfig.STATE[f'{user_id}_gift_to'] = gift_to
         TgConfig.STATE[f'{user_id}_gift_name'] = gift_name
-
-
-
-    if user_balance > 0:
-        TgConfig.STATE[user_id] = 'use_balance'
-        await bot.edit_message_text(
-            t(lang, 'use_balance_prompt', balance=f'{user_balance:.2f}'),
-            chat_id=call.message.chat.id,
-            message_id=msg,
-            reply_markup=use_balance_menu(item_name, lang),
-        )
-    else:
-        TgConfig.STATE[f'{user_id}_deduct'] = 0
-        TgConfig.STATE[user_id] = 'purchase_crypto'
-        await bot.edit_message_text(
-            t(lang, 'choose_crypto'),
-            chat_id=call.message.chat.id,
-            message_id=msg,
-            reply_markup=crypto_choice_purchase(item_name, lang),
-        )
-
-
-async def use_balance_handler(call: CallbackQuery):
-    """Handle user's decision to use balance before paying invoice."""
-    bot, user_id = await get_bot_user_ids(call)
-    item_name = TgConfig.STATE.get(f'{user_id}_pending_item')
-    price = TgConfig.STATE.get(f'{user_id}_price')
-    lang = get_user_language(user_id) or 'en'
-    balance = get_user_balance(user_id)
-
-    if call.data == 'use_balance_yes':
-        TgConfig.STATE[f'{user_id}_deduct'] = balance
-        amount = price - balance
-    else:
-        TgConfig.STATE[f'{user_id}_deduct'] = 0
-        amount = price
-    TgConfig.STATE[user_id] = 'purchase_crypto'
-    await bot.edit_message_text(
-        t(lang, 'choose_crypto'),
-        chat_id=call.message.chat.id,
-        message_id=call.message.message_id,
-        reply_markup=crypto_choice_purchase(item_name, lang),
-    )
 
 
 
@@ -1952,6 +1916,7 @@ async def checking_payment(call: CallbackQuery):
                         logger.info(f"User {user_id} unlocked achievement first_purchase")
                     TgConfig.STATE.pop(f'{user_id}_pending_item', None)
                     TgConfig.STATE.pop(f'{user_id}_price', None)
+                    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
                     TgConfig.STATE.pop(f'{user_id}_deduct', None)
                     await bot.send_message(user_id, t(lang, 'top_up_completed'))
                     if not has_user_achievement(user_id, 'first_topup'):
@@ -1970,6 +1935,7 @@ async def checking_payment(call: CallbackQuery):
                     )
                     TgConfig.STATE.pop(f'{user_id}_pending_item', None)
                     TgConfig.STATE.pop(f'{user_id}_price', None)
+                    TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
 
                     await bot.send_message(user_id, t(lang, 'top_up_completed'))
 
@@ -2037,6 +2003,7 @@ async def cancel_payment(call: CallbackQuery):
                     await notify_restock(bot, purchase_data['item'])
         TgConfig.STATE.pop(f'{user_id_db}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id_db}_price', None)
+        TgConfig.STATE.pop(f'{user_id_db}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id_db}_deduct', None)
         try:
             await bot.delete_message(user_id_db, message_id)
@@ -2073,6 +2040,7 @@ async def check_sub_to_channel(call: CallbackQuery):
                     await notify_restock(bot, purchase_data['item'])
         TgConfig.STATE.pop(f'{user_id}_pending_item', None)
         TgConfig.STATE.pop(f'{user_id}_price', None)
+        TgConfig.STATE.pop(f'{user_id}_promo_applied', None)
         TgConfig.STATE.pop(f'{user_id}_deduct', None)
         reserve_msg_id = TgConfig.STATE.pop(f'{user_id}_reserve_msg', None)
         if reserve_msg_id:
@@ -2238,9 +2206,6 @@ def register_user_handlers(dp: Dispatcher):
                                        lambda c: c.data.startswith('crypto_'), state='*')
 
 
-
-    dp.register_callback_query_handler(use_balance_handler,
-                                       lambda c: c.data in ('use_balance_yes', 'use_balance_no'), state='*')
 
     dp.register_callback_query_handler(purchase_crypto_payment,
                                        lambda c: c.data.startswith('buycrypto_'), state='*')

--- a/bot/keyboards/inline.py
+++ b/bot/keyboards/inline.py
@@ -258,12 +258,15 @@ def console(role: int) -> InlineKeyboardMarkup:
     inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
-def confirm_purchase_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
+def confirm_purchase_menu(item_name: str, lang: str, show_promo: bool = True) -> InlineKeyboardMarkup:
     inline_keyboard = [
-        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')],
-        [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')],
-        [InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')]
+        [InlineKeyboardButton(t(lang, 'purchase_button'), callback_data=f'buy_{item_name}')]
     ]
+    if show_promo:
+        inline_keyboard.append(
+            [InlineKeyboardButton(t(lang, 'apply_promo'), callback_data=f'applypromo_{item_name}')]
+        )
+    inline_keyboard.append([InlineKeyboardButton('🔙 Grįžti į meniu', callback_data='back_to_menu')])
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 
 
@@ -614,33 +617,6 @@ def crypto_choice() -> InlineKeyboardMarkup:
          InlineKeyboardButton('ETH', callback_data='crypto_ETH')],
         [InlineKeyboardButton('LTC', callback_data='crypto_LTC')],
         [InlineKeyboardButton('🔙 Go back', callback_data='replenish_balance')]
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
-def crypto_choice_purchase(item_name: str, lang: str) -> InlineKeyboardMarkup:
-    """Return crypto choice markup for product purchase."""
-    inline_keyboard = [
-        [InlineKeyboardButton('SOL', callback_data='buycrypto_SOL'),
-         InlineKeyboardButton('BTC', callback_data='buycrypto_BTC')],
-        [InlineKeyboardButton('TRX', callback_data='buycrypto_TRX'),
-         InlineKeyboardButton('TON', callback_data='buycrypto_TON')],
-        [InlineKeyboardButton('USDT (TRC20)', callback_data='buycrypto_USDTTRC20'),
-         InlineKeyboardButton('ETH', callback_data='buycrypto_ETH')],
-        [InlineKeyboardButton('LTC', callback_data='buycrypto_LTC')],
-        [InlineKeyboardButton(t(lang, 'back'), callback_data=f'item_{item_name}')],
-    ]
-    return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
-
-
-
-
-def use_balance_menu(item_name: str, lang: str) -> InlineKeyboardMarkup:
-    """Ask whether to use current balance for purchase."""
-    inline_keyboard = [
-        [
-            InlineKeyboardButton(t(lang, 'yes'), callback_data='use_balance_yes'),
-            InlineKeyboardButton(t(lang, 'no'), callback_data='use_balance_no'),
-        ],
-        [InlineKeyboardButton(t(lang, 'back'), callback_data=f'item_{item_name}')],
     ]
     return InlineKeyboardMarkup(inline_keyboard=inline_keyboard)
 

--- a/bot/utils/level.py
+++ b/bot/utils/level.py
@@ -29,7 +29,7 @@ LEVEL_NAMES = {
 
 
 def get_level_info(purchases: int, lang: str = 'lt'):
-    """Return level name and discount for purchase count."""
+    """Return level name, discount and progress battery for purchase count."""
     if purchases < 0:
         purchases = 0
     level_index = 0
@@ -41,7 +41,6 @@ def get_level_info(purchases: int, lang: str = 'lt'):
     names = LEVEL_NAMES.get(lang, LEVEL_NAMES['lt'])
     level_name = names[level_index]
     discount = level_index * 2
-    return level_name, discount
 
     if level_index < len(LEVEL_THRESHOLDS) - 1:
         next_threshold = LEVEL_THRESHOLDS[level_index + 1]


### PR DESCRIPTION
## Summary
- ensure media description input handler accepts text messages
- delay coinflip result announcement by 4 seconds after animations
- correct achievement user count query
- import language helper in photo-description handler to avoid NameError
- enforce single-use promo codes by tracking usage and hiding the apply option
- automatically deduct user balance and invoice only the remaining amount when purchasing
- return level name, discount, and battery from loyalty helper to prevent purchase errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf5b9896c8332a9e1e99e88f5d51c